### PR TITLE
java version18→20に変更し、起動時のエラーを解消

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK (java18)
+      - name: Set up JDK (java20)
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 20
           distribution: corretto
 
       - name: Cache local Maven repository
@@ -49,10 +49,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK (java18)
+      - name: Set up JDK (java20)
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 20
           distribution: corretto
 
       - name: Cache local Maven repository
@@ -88,10 +88,10 @@ jobs:
       - name: Build test database
         run: docker compose up test-db -d
 
-      - name: Set up JDK (java18)
+      - name: Set up JDK (java20)
         uses: actions/setup-java@v3
         with:
-          java-version: 18
+          java-version: 20
           distribution: corretto
 
       - name: Cache local Maven repository

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - "**"
+          - "sample.domain.**"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,9 +42,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - "app.service.**"
-          - "app.transaction.**"
-          - "app.controller.**"
+          - "**"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -68,7 +66,7 @@ jobs:
         run: >
           ./mvnw -f pom.xml
           -Duser.timezone=UTC
-          -Dtest="com.accelhack.application.api.${{ matrix.test }}"
+          -Dtest="com.accelhack.spring.api.${{ matrix.test }}"
           -s settings.xml
           test
 
@@ -107,6 +105,6 @@ jobs:
         run: >
           ./mvnw -f pom.xml
           -Duser.timezone=UTC
-          -Dtest="com.accelhack.application.api.${{ matrix.test }}"
+          -Dtest="com.accelhack.spring.api.${{ matrix.test }}"
           -s settings.xml
           test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -77,8 +77,7 @@ jobs:
     strategy:
       matrix:
         test:
-          - "app.mapper.**"
-          - "app.operation.**"
+          - "**"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </parent>
 
     <properties>
-        <java.version>18</java.version>
+        <java.version>20</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -190,8 +190,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>18</source>
-                    <target>18</target>
+                    <source>20</source>
+                    <target>20</target>
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
             </plugin>

--- a/src/test/java/com/accelhack/spring/api/sample/domain/SampleTests.java
+++ b/src/test/java/com/accelhack/spring/api/sample/domain/SampleTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 public class SampleTests {
 
-    @Test
-    public void testBuilder() {
-    }
+  @Test
+  public void testBuilder() {}
 }

--- a/src/test/java/com/accelhack/spring/api/sample/domain/SampleTests.java
+++ b/src/test/java/com/accelhack/spring/api/sample/domain/SampleTests.java
@@ -1,0 +1,10 @@
+package com.accelhack.spring.api.sample.domain;
+
+import org.junit.jupiter.api.Test;
+
+public class SampleTests {
+
+    @Test
+    public void testBuilder() {
+    }
+}


### PR DESCRIPTION
# 概要
- javaのversion18指定になっているが、18だとエラーがでる機能を使っているため、20に変更
- テストが存在しないためにgithub actionが落ちる問題を修正